### PR TITLE
Add Supabase walk tracking and clean up walk plans

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://rckvorqlhmpnxpmyunze.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_u5YoEH3uJFjxm6y37boDSg_U7UWis5q

--- a/app/(auth)/signin/page.tsx
+++ b/app/(auth)/signin/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useState } from "react";
+import { supabase } from "@/lib/supabase/client";
+
+export default function SignIn() {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) alert(error.message); else setSent(true);
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Sign in</h1>
+      {sent ? <p>Check your email for the magic link.</p> : (
+        <form onSubmit={onSubmit} className="space-y-3">
+          <input className="w-full border rounded p-2" type="email" placeholder="you@example.com" value={email} onChange={e=>setEmail(e.target.value)} required/>
+          <button className="btn btn-primary w-full">Send magic link</button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/api/walks/end/route.ts
+++ b/app/api/walks/end/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServer } from "@/lib/supabase/server";
+
+const schema = z.object({
+  walkId: z.string().uuid(),
+  durationS: z.number().int().nonnegative(),
+  distanceM: z.number().nonnegative()
+});
+
+export async function POST(req: Request) {
+  const supabase = createSupabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: "Bad payload" }, { status: 400 });
+
+  const { error } = await supabase
+    .from("walks")
+    .update({
+      ended_at: new Date().toISOString(),
+      total_duration_s: parsed.data.durationS,
+      total_distance_m: parsed.data.distanceM
+    })
+    .eq("id", parsed.data.walkId)
+    .eq("user_id", user.id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/walks/points/route.ts
+++ b/app/api/walks/points/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { createSupabaseServer } from "@/lib/supabase/server";
+
+const schema = z.object({
+  walkId: z.string().uuid(),
+  points: z.array(z.object({
+    ts: z.string().datetime(),
+    lat: z.number(),
+    lng: z.number(),
+    accuracy: z.number().nullish(),
+    speed: z.number().nullish(),
+    heading: z.number().nullish(),
+  })).min(1),
+});
+
+export async function POST(req: Request) {
+  const supabase = createSupabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await req.json();
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) return NextResponse.json({ error: "Bad payload" }, { status: 400 });
+
+  const rows = parsed.data.points.map(p => ({ ...p, walk_id: parsed.data.walkId, user_id: user.id }));
+  const { error } = await supabase.from("walk_points").insert(rows);
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/walks/start/route.ts
+++ b/app/api/walks/start/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { createSupabaseServer } from "@/lib/supabase/server";
+
+export async function POST() {
+  const supabase = createSupabaseServer();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { data, error } = await supabase.from("walks").insert({ user_id: user.id }).select("id").single();
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ walkId: data.id });
+}

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,15 @@
+import Navigation from "@/components/Navigation";
+
+export default function PrivacyPolicy() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <main className="max-w-3xl mx-auto px-4 py-16 space-y-4">
+        <h1 className="text-4xl font-bold text-gray-900">Privacy Policy</h1>
+        <p>We collect location data only during active walks that you start and end.</p>
+        <p>For each walk we store the GPS points, total distance, and duration.</p>
+        <p>You may request deletion of this information at any time by emailing us.</p>
+      </main>
+    </div>
+  );
+}

--- a/app/walk-plans/page.tsx
+++ b/app/walk-plans/page.tsx
@@ -1,7 +1,6 @@
 import { WalkPlan } from '@/types'
 import WalkPlanCard from '@/components/WalkPlanCard'
 import Navigation from '@/components/Navigation'
-import { MapPin, Clock, DollarSign } from 'lucide-react'
 
 // Actual walk offerings
 const walkPlans: WalkPlan[] = [
@@ -42,32 +41,9 @@ export default function WalkPlansPage() {
             Walk Plans
           </h1>
           <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-            Choose from our variety of walk plans designed to meet your dog's needs. 
-            All walks include GPS tracking and detailed reports.
+            Choose from our variety of walk plans designed to meet your dog's needs.
           </p>
-        </div>
-
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-12">
-          <div className="bg-white rounded-lg p-6 text-center">
-            <MapPin className="h-8 w-8 text-primary-600 mx-auto mb-2" />
-            <div className="text-2xl font-bold text-gray-900">{walkPlans.length}</div>
-            <div className="text-gray-600">Available Plans</div>
-          </div>
-          <div className="bg-white rounded-lg p-6 text-center">
-            <Clock className="h-8 w-8 text-primary-600 mx-auto mb-2" />
-            <div className="text-2xl font-bold text-gray-900">
-              {walkPlans.reduce((total, plan) => total + plan.duration, 0)} min
-            </div>
-            <div className="text-gray-600">Total Walk Time</div>
-          </div>
-          <div className="bg-white rounded-lg p-6 text-center">
-            <DollarSign className="h-8 w-8 text-primary-600 mx-auto mb-2" />
-            <div className="text-2xl font-bold text-gray-900">
-              ${walkPlans.reduce((total, plan) => total + plan.price, 0)}
-            </div>
-            <div className="text-gray-600">Total Value</div>
-          </div>
+          <p className="mt-2 text-gray-700">GPS tracking & photo update: Included</p>
         </div>
 
         {/* Walk Plans Grid */}

--- a/app/walks/live/page.tsx
+++ b/app/walks/live/page.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useWalkTracker } from "@/hooks/useWalkTracker";
+
+export default function LiveWalk() {
+  const { start, end, isTracking, distanceM, durationS } = useWalkTracker();
+  const mins = Math.floor(durationS / 60), secs = durationS % 60;
+
+  return (
+    <div className="max-w-md mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Live Walk</h1>
+      <p className="text-sm text-muted-foreground">We only track during a walk you start and end. Keep your screen on for best GPS reliability.</p>
+      <div className="rounded border p-4">
+        <div>Distance: {(distanceM/1000).toFixed(2)} km</div>
+        <div>Duration: {mins}:{secs.toString().padStart(2,"0")}</div>
+      </div>
+      {!isTracking ? (
+        <button className="btn btn-primary w-full" onClick={start}>Start Walk</button>
+      ) : (
+        <button className="btn w-full" onClick={end}>End Walk</button>
+      )}
+      <p className="text-sm text-muted-foreground">GPS tracking & photo report included with every walk.</p>
+    </div>
+  );
+}

--- a/components/WalkPlanCard.tsx
+++ b/components/WalkPlanCard.tsx
@@ -66,7 +66,7 @@ export default function WalkPlanCard({ walkPlan, onClick }: WalkPlanCardProps) {
       </div>
       
       <div className="mt-4 pt-4 border-t border-gray-100">
-        <Link href="/book" className="w-full btn-primary block text-center">
+        <Link href={`/book/walk?length=${walkPlan.duration}`} className="w-full btn-primary block text-center">
           Book This Plan
         </Link>
       </div>

--- a/hooks/useWalkTracker.ts
+++ b/hooks/useWalkTracker.ts
@@ -1,0 +1,91 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+type Point = { ts: string; lat: number; lng: number; accuracy?: number|null; speed?: number|null; heading?: number|null; };
+
+const haversine = (a: Point, b: Point) => {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h = Math.sin(dLat/2)**2 + Math.cos(lat1)*Math.cos(lat2)*Math.sin(dLon/2)**2;
+  return 2 * R * Math.asin(Math.sqrt(h));
+};
+
+export function useWalkTracker() {
+  const [walkId, setWalkId] = useState<string|null>(null);
+  const [isTracking, setIsTracking] = useState(false);
+  const [distanceM, setDistanceM] = useState(0);
+  const [durationS, setDurationS] = useState(0);
+  const watchId = useRef<number|null>(null);
+  const buffer = useRef<Point[]>([]);
+  const last = useRef<Point|null>(null);
+  const startMs = useRef<number|null>(null);
+
+  async function flush() {
+    if (!walkId || buffer.current.length === 0) return;
+    const chunk = buffer.current.splice(0, buffer.current.length);
+    await fetch("/api/walks/points", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ walkId, points: chunk })
+    });
+  }
+
+  function tick() {
+    if (!startMs.current) return;
+    setDurationS(Math.floor((Date.now() - startMs.current) / 1000));
+  }
+
+  async function start() {
+    const res = await fetch("/api/walks/start", { method: "POST" });
+    if (!res.ok) { alert("Please sign in first."); return; }
+    const { walkId } = await res.json();
+    setWalkId(walkId); setIsTracking(true);
+    setDistanceM(0); setDurationS(0); startMs.current = Date.now();
+
+    watchId.current = navigator.geolocation.watchPosition(
+      pos => {
+        const p: Point = {
+          ts: new Date(pos.timestamp).toISOString(),
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+          speed: pos.coords.speed,
+          heading: pos.coords.heading
+        };
+        if (last.current) setDistanceM(d => d + haversine(last.current!, p));
+        last.current = p;
+        buffer.current.push(p);
+        if (buffer.current.length >= 8) flush();
+        tick();
+      },
+      err => console.warn("geo error", err),
+      { enableHighAccuracy: true, maximumAge: 0, timeout: 15000 }
+    );
+  }
+
+  async function end() {
+    if (watchId.current !== null) navigator.geolocation.clearWatch(watchId.current);
+    await flush();
+    if (walkId) {
+      await fetch("/api/walks/end", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ walkId, durationS, distanceM })
+      });
+    }
+    setIsTracking(false); setWalkId(null); last.current = null; startMs.current = null;
+  }
+
+  useEffect(() => {
+    if (!isTracking) return;
+    const flushTimer = setInterval(flush, 10000);
+    const tickTimer = setInterval(tick, 1000);
+    return () => { clearInterval(flushTimer); clearInterval(tickTimer); };
+  }, [isTracking]);
+
+  return { start, end, isTracking, distanceM, durationS };
+}

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,7 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
+);

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { createServerClient } from "@supabase/ssr";
+
+export function createSupabaseServer() {
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) { return cookies().get(name)?.value; },
+        set() {},
+        remove() {}
+      }
+    }
+  );
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "sanity": "^4.3.0",
     "styled-components": "^6.1.18",
     "tailwindcss": "^3.4.0",
-    "typescript": "^5.8"
+    "typescript": "^5.8",
+    "@supabase/supabase-js": "^2.45.0",
+    "@supabase/ssr": "^0.5.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^5.0.2",


### PR DESCRIPTION
## Summary
- integrate Supabase client and server helpers with anon key
- add magic link sign-in, GPS walk tracker hook, live walk page and API routes
- simplify walk plans with direct booking links and privacy policy

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b93b514388331b120b66e094b650c