### PR TITLE
fix: install dev dependencies on vercel builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,6 @@
         "@sanity/vision": "^4.3.0",
         "@supabase/ssr": "^0.5.0",
         "@supabase/supabase-js": "^2.45.0",
-        "@types/node": "^20.0.0",
-        "@types/react": "^18.2.0",
-        "@types/react-dom": "^18.2.0",
         "autoprefixer": "^10.4.0",
         "lucide-react": "^0.294.0",
         "next": "^14.2.31",
@@ -28,17 +25,20 @@
         "sanity": "^4.3.0",
         "styled-components": "^6.1.18",
         "tailwindcss": "^3.4.0",
-        "typescript": "^5.8",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@sanity/eslint-config-studio": "^5.0.2",
+        "@types/node": "^20.0.0",
+        "@types/react": "^18.2.0",
+        "@types/react-dom": "^18.2.0",
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.0.0",
-        "prettier": "^3.5"
+        "prettier": "^3.5",
+        "typescript": "^5.4.5"
       },
       "engines": {
-        "node": ">=18.18.0 <21",
+        "node": "20.19.3",
         "npm": ">=9"
       }
     },
@@ -6364,6 +6364,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -17642,6 +17643,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "@sanity/vision": "^4.3.0",
     "@supabase/ssr": "^0.5.0",
     "@supabase/supabase-js": "^2.45.0",
-    "@types/node": "^20.0.0",
-    "@types/react": "^18.2.0",
-    "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.0",
     "lucide-react": "^0.294.0",
     "next": "^14.2.31",
@@ -44,6 +41,9 @@
   },
   "devDependencies": {
     "@sanity/eslint-config-studio": "^5.0.2",
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.0.0",
     "prettier": "^3.5",
@@ -56,8 +56,9 @@
     "singleQuote": true
   },
   "engines": {
-    "node": ">=18.18.0 <21",
+    "node": "20.19.3",
     "npm": ">=9"
   },
+  "engineStrict": false,
   "packageManager": "npm@10"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "buildCommand": "npm run build",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "installCommand": "npm ci --omit=dev --legacy-peer-deps"
-} 
+  "installCommand": "npm ci --legacy-peer-deps"
+}


### PR DESCRIPTION
## Summary
- ensure Typescript and React type packages are listed in devDependencies
- set Node 20.19.3 engine with engineStrict disabled
- update Vercel install command to keep dev deps during build

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f551472748331931f77875ea0ce95